### PR TITLE
SHIP-2368 Fix PHP 7.4 Notices

### DIFF
--- a/Model/EagerLoader.php
+++ b/Model/EagerLoader.php
@@ -527,6 +527,10 @@ class EagerLoader {
 		$many = (stripos($type, 'many') !== false);
 		$belong = (stripos($type, 'belong') !== false);
 
+		$habtmAlias = null;
+		$habtm = null;
+		$habtmParentKey = null;
+		$habtmTargetKey = null;
 		if ($has && $belong) {
 			$parentKey = $parent->primaryKey;
 			$targetKey = $target->primaryKey;
@@ -542,10 +546,12 @@ class EagerLoader {
 			$targetKey = $target->primaryKey;
 		}
 
+		$external = false;
 		if (!empty($relation['external'])) {
 			$external = true;
 		}
 
+		$finderQuery = null;
 		if (!empty($relation['finderQuery'])) {
 			$finderQuery = $relation['finderQuery'];
 		}


### PR DESCRIPTION
Fix notices triggered by passing undefined variables into `compact()` by always initializing variables that are conditionally assigned.